### PR TITLE
Sbgn converter improvements

### DIFF
--- a/gsea-converter/pom.xml
+++ b/gsea-converter/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.biopax.paxtools</groupId>
     <artifactId>paxtools</artifactId>
-    <version>5.2.0-SNAPSHOT</version>
+    <version>5.2.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/json-converter/pom.xml
+++ b/json-converter/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>paxtools</artifactId>
 		<groupId>org.biopax.paxtools</groupId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.2.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>json-converter</artifactId>
 	<name>BioPAX to/from JSON Converter</name>

--- a/normalizer/pom.xml
+++ b/normalizer/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<artifactId>paxtools</artifactId>
 		<groupId>org.biopax.paxtools</groupId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.2.1-SNAPSHOT</version>
 	</parent>
 
 	<url>https://biopax.github.io/Paxtools</url>

--- a/pattern/pom.xml
+++ b/pattern/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
     	<groupId>org.biopax.paxtools</groupId>
 		<artifactId>paxtools</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.2.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>pattern</artifactId>

--- a/paxtools-archetype/pom.xml
+++ b/paxtools-archetype/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>paxtools</artifactId>
 		<groupId>org.biopax.paxtools</groupId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.2.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>paxtools-archetype</artifactId>

--- a/paxtools-console/pom.xml
+++ b/paxtools-console/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>paxtools</artifactId>
 		<groupId>org.biopax.paxtools</groupId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.2.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>paxtools-console</artifactId>
 	<packaging>jar</packaging>

--- a/paxtools-console/src/main/java/org/biopax/paxtools/PaxtoolsMain.java
+++ b/paxtools-console/src/main/java/org/biopax/paxtools/PaxtoolsMain.java
@@ -38,15 +38,15 @@ import java.util.zip.GZIPInputStream;
  * Various console utility functions
  */
 public final class PaxtoolsMain {
-    final static Logger log = LoggerFactory.getLogger(PaxtoolsMain.class);
+	final static Logger log = LoggerFactory.getLogger(PaxtoolsMain.class);
 
-    private static SimpleIOHandler io;
+	private static SimpleIOHandler io;
 
-    private PaxtoolsMain() {
-    	throw new UnsupportedOperationException("Non-instantiable utility class.");
+	private PaxtoolsMain() {
+		throw new UnsupportedOperationException("Non-instantiable utility class.");
 	}
 
-    static {
+	static {
 		io = new SimpleIOHandler();
 		io.mergeDuplicates(true);
 	}
@@ -57,7 +57,7 @@ public final class PaxtoolsMain {
 	 *
 	 * TODO: should not be public API, but is already used from ext. apps, such as PaxtoolsR...
 	 */
-    public static void toGSEA(String[] argv) throws IOException {
+	public static void toGSEA(String[] argv) throws IOException {
 		//argv[0] is the command name ('toGsea')
 		boolean crossSpecies = false; //cross-check is enabled (i.e., no mixing different species IDs in one row)
 		boolean subPathways = false; //no sub-pathways (i.e., going into sub-pathways is not enabled)
@@ -91,7 +91,7 @@ public final class PaxtoolsMain {
 		gseaConverter.setSkipOutsidePathways(!notPathways);
 		gseaConverter.setAllowedOrganisms(organisms);//if organisms is empty then all species are allowed (no filtering)
 		gseaConverter.writeToGSEA(io.convertFromOWL(getInputStream(argv[1])), new FileOutputStream(argv[2]));
-    }
+	}
 
 	/*
 	 *
@@ -101,45 +101,45 @@ public final class PaxtoolsMain {
 	 * @throws IOException
 	 */
 	public static void getNeighbors(String[] argv) throws IOException
-    {
-        // set strings vars
-        String in = argv[1];
-        String[] ids = argv[2].split(",");
-        String out = argv[3];
+	{
+		// set strings vars
+		String in = argv[1];
+		String[] ids = argv[2].split(",");
+		String out = argv[3];
 
-        // read BioPAX from the file
-        Model model = io.convertFromOWL(getInputStream(in));
+		// read BioPAX from the file
+		Model model = io.convertFromOWL(getInputStream(in));
 
-        // get elements (entities)
-        Set<BioPAXElement> elements = new HashSet<BioPAXElement>();
-        for (Object id : ids) {
-            BioPAXElement e = model.getByID(id.toString());
-            if (e != null && (e instanceof Entity || e instanceof entity)) {
-                elements.add(e);
-            } else {
-                log.warn("Source element not found: " + id);
-            }
-        }
+		// get elements (entities)
+		Set<BioPAXElement> elements = new HashSet<BioPAXElement>();
+		for (Object id : ids) {
+			BioPAXElement e = model.getByID(id.toString());
+			if (e != null && (e instanceof Entity || e instanceof entity)) {
+				elements.add(e);
+			} else {
+				log.warn("Source element not found: " + id);
+			}
+		}
 
-        // execute the 'nearest neighborhood' query
-        Set<BioPAXElement> result = QueryExecuter
-        		.runNeighborhood(elements, model, 1, Direction.BOTHSTREAM);
+		// execute the 'nearest neighborhood' query
+		Set<BioPAXElement> result = QueryExecuter
+			.runNeighborhood(elements, model, 1, Direction.BOTHSTREAM);
 
-        // auto-complete/clone the results in a new model
-        // (this also cuts some less important edges, right?..)
-        Completer c = new Completer(io.getEditorMap());
-        result = c.complete(result, model);
-        Cloner cln = new Cloner(io.getEditorMap(), io.getFactory());
-        model = cln.clone(model, result); // new sub-model
+		// auto-complete/clone the results in a new model
+		// (this also cuts some less important edges, right?..)
+		Completer c = new Completer(io.getEditorMap());
+		result = c.complete(result, model);
+		Cloner cln = new Cloner(io.getEditorMap(), io.getFactory());
+		model = cln.clone(model, result); // new sub-model
 
-        if (model != null) {
-            log.info("Elements in the result model: " + model.getObjects().size());
-            // export to OWL
-            io.convertToOWL(model, new FileOutputStream(out));
-        } else {
-            log.error("NULL model returned.");
-        }
-    }
+		if (model != null) {
+			log.info("Elements in the result model: " + model.getObjects().size());
+			// export to OWL
+			io.convertToOWL(model, new FileOutputStream(out));
+		} else {
+			log.error("NULL model returned.");
+		}
+	}
 
 	/*
 	 * TODO: should not be public API, but is already used from ext. apps, such as PaxtoolsR...
@@ -147,9 +147,9 @@ public final class PaxtoolsMain {
 	 * @throws IOException
 	 */
 	public static void fetch(String[] argv) throws IOException {
-        // set strings vars
-        String in = argv[1];
-        String out = argv[2];
+		// set strings vars
+		String in = argv[1];
+		String out = argv[2];
 		String[] uris = new String[0]; //empty means - all
 		boolean absoluteUris = false;
 		if(argv.length > 3) {
@@ -166,7 +166,7 @@ public final class PaxtoolsMain {
 
 		// import the model
 		log.info("Loading the BioPAX model from " + in);
-        Model model = io.convertFromOWL(getInputStream(in));
+		Model model = io.convertFromOWL(getInputStream(in));
 		log.info("Successfully loaded the BioPAX model. Writing to the output: " + out);
 
 		// extract and save the (sub-)model
@@ -178,20 +178,20 @@ public final class PaxtoolsMain {
 			biopaxWriter.convertToOWL(model, new FileOutputStream(out));
 
 		log.info("Done.");
-    }
+	}
 
-    
-    /*
-     * Detects and converts a BioPAX Level 1, 2,
-     * or PSI-MI/MITAB model to BioPAX Level3..
+
+	/*
+	 * Detects and converts a BioPAX Level 1, 2,
+	 * or PSI-MI/MITAB model to BioPAX Level3..
 	 *
 	 * TODO: should not be public API, but is already used from ext. apps, such as PaxtoolsR...
-     */
-    public static void toLevel3(String[] argv) throws IOException {
-    	final String input = argv[1];
-    	final String output = argv[2];
-    	
-    	boolean forcePsiInteractionToComplex = false;
+	 */
+	public static void toLevel3(String[] argv) throws IOException {
+		final String input = argv[1];
+		final String output = argv[2];
+
+		boolean forcePsiInteractionToComplex = false;
 		if(argv.length > 3) {
 			for(int i=3; i<argv.length; i++) {
 				String param = argv[i];
@@ -206,8 +206,8 @@ public final class PaxtoolsMain {
 		InputStream is = getInputStream(input);
 		FileOutputStream os = new FileOutputStream(output);
 
-    	try {
-    		switch (type) {
+		try {
+			switch (type) {
 				case BIOPAX:
 					Model model = io.convertFromOWL(is);
 					model = (new LevelUpgrader()).filter(model);
@@ -228,21 +228,21 @@ public final class PaxtoolsMain {
 					psimiConverter.convertTab(is, os, forcePsiInteractionToComplex);
 					os.close();
 					break;
-    		}
+			}
 
-    	} catch (Exception e) {
-    		throw new RuntimeException("Failed to convert " +
-    				input + "to BioPAX L3", e);
-    	}
-    }
-    
-    private enum Type {
-    	BIOPAX,
-    	PSIMI,
-    	PSIMITAB
-    }
-    
-    //read a few lines to detect it's a BioPAX vs. PSI-MI vs. PSI-MITAB data.
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to convert " +
+				input + "to BioPAX L3", e);
+		}
+	}
+
+	private enum Type {
+		BIOPAX,
+		PSIMI,
+		PSIMITAB
+	}
+
+	//read a few lines to detect it's a BioPAX vs. PSI-MI vs. PSI-MITAB data.
 	private static Type detect(String input) {
 		StringBuilder sb = new StringBuilder();
 		try {
@@ -255,7 +255,7 @@ public final class PaxtoolsMain {
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}
-		
+
 		String buf = sb.toString();
 		if (buf.contains("<rdf:RDF") && buf.contains("http://www.biopax.org/release/biopax")) {
 			return Type.BIOPAX;
@@ -267,17 +267,15 @@ public final class PaxtoolsMain {
 			return Type.PSIMITAB; //default/guess
 	}
 
-    /*
-     *  Converts a BioPAX file to SBGN and saves it in a file.
-     *
-     *  TODO: should not be public API, but is already used from ext. apps, such as PaxtoolsR...
-     */
-    public static void toSbgn(String[] argv) throws IOException
-    {
-        String input = argv[1];
+	/*
+	 *  Converts a BioPAX file to SBGN and saves it in a file.
+	 *
+	 *  TODO: should not be public API, but is already used from ext. apps, such as PaxtoolsR...
+	 */
+	public static void toSbgn(String[] argv) throws IOException {
+		String input = argv[1];
 		String output = argv[2];
 		Model model = io.convertFromOWL(getInputStream(input));
-
 		boolean doLayout = true;
 		if(argv.length > 3) {
 			for(int i=3; i<argv.length; i++) {
@@ -298,32 +296,32 @@ public final class PaxtoolsMain {
 		} else {
 			log.info("toSBGN: not blacklisting any ubiquitous molecules (no blacklist.txt found)");
 		}
+
 		final UbiqueDetector ubd = (blackList != null) ? new ListUbiqueDetector(blackList.getListed()) : null;
-
-        L3ToSBGNPDConverter l3ToSBGNPDConverter = new L3ToSBGNPDConverter(ubd, null, doLayout);
+		L3ToSBGNPDConverter l3ToSBGNPDConverter = new L3ToSBGNPDConverter(ubd, null, doLayout);
 		l3ToSBGNPDConverter.writeSBGN(model, output);
-    }
+	}
 
-    
-    /*
-     * Checks files by the online BioPAX validator using the built-in BioPAX validator client.
-     * 
-     * See about <a href="http://www.biopax.org/validator">BioPAX Validator Webservice</a>
-     *
-     * TODO: should not be public API, but is already used from ext. apps, such as PaxtoolsR...
-     */
-    public static void validate(String[] argv) throws IOException
-    {
-        String input = argv[1];
-        String output = argv[2];
-        // default options
-        RetFormat outf = RetFormat.HTML;
-        boolean fix = false;
-        Integer maxErrs = null;
-        Behavior level = null; //will report both errors and warnings
-        String profile = null;
-        
-        // match optional args
+
+	/*
+	 * Checks files by the online BioPAX validator using the built-in BioPAX validator client.
+	 *
+	 * See about <a href="http://www.biopax.org/validator">BioPAX Validator Webservice</a>
+	 *
+	 * TODO: should not be public API, but is already used from ext. apps, such as PaxtoolsR...
+	 */
+	public static void validate(String[] argv) throws IOException
+	{
+		String input = argv[1];
+		String output = argv[2];
+		// default options
+		RetFormat outf = RetFormat.HTML;
+		boolean fix = false;
+		Integer maxErrs = null;
+		Behavior level = null; //will report both errors and warnings
+		String profile = null;
+
+		// match optional args
 		for (int i = 3; i < argv.length; i++) {
 			if ("html".equalsIgnoreCase(argv[i])) {
 				outf = RetFormat.HTML;
@@ -343,66 +341,66 @@ public final class PaxtoolsMain {
 			}
 		}
 
-        Collection<File> files = new HashSet<File>();
-        File fileOrDir = new File(input);
-        if (!fileOrDir.canRead()) {
-            System.out.println("Cannot read " + input);
-        }
+		Collection<File> files = new HashSet<File>();
+		File fileOrDir = new File(input);
+		if (!fileOrDir.canRead()) {
+			System.out.println("Cannot read " + input);
+		}
 
-        // collect files
-        if (fileOrDir.isDirectory()) {
-            // validate all the OWL files in the folder
-            FilenameFilter filter = new FilenameFilter() {
-                public boolean accept(File dir, String name) {
-                    return (name.endsWith(".owl"));
-                }
-            };
-            for (String s : fileOrDir.list(filter)) {
-                files.add(new File(fileOrDir.getCanonicalPath()
-                        + File.separator + s));
-            }
-        } else {
-            files.add(fileOrDir);
-        }
+		// collect files
+		if (fileOrDir.isDirectory()) {
+			// validate all the OWL files in the folder
+			FilenameFilter filter = new FilenameFilter() {
+				public boolean accept(File dir, String name) {
+					return (name.endsWith(".owl"));
+				}
+			};
+			for (String s : fileOrDir.list(filter)) {
+				files.add(new File(fileOrDir.getCanonicalPath()
+					+ File.separator + s));
+			}
+		} else {
+			files.add(fileOrDir);
+		}
 
-        // upload and validate using the default URL:
-        // http://www.biopax.org/biopax-validator/check.html
-        OutputStream os = new FileOutputStream(output);
-        try {
-            if (!files.isEmpty()) {
-                BiopaxValidatorClient val = new BiopaxValidatorClient();
-                val.validate(fix, profile, outf, level, maxErrs, null, files.toArray(new File[]{}), os);
-            }
-        } catch (Exception ex) {
-            // fall-back: not using the remote validator; trying to read files
-            String msg = "Unable to check with the biopax-validator web service: \n " +
-            		ex.toString() + 
-            		"\n Fall-back: trying to parse the file(s) with paxtools " +
-            		"(up to the first syntax error in each file)...\n";
-            log.error(msg, ex);
-            os.write(msg.getBytes());
+		// upload and validate using the default URL:
+		// http://www.biopax.org/biopax-validator/check.html
+		OutputStream os = new FileOutputStream(output);
+		try {
+			if (!files.isEmpty()) {
+				BiopaxValidatorClient val = new BiopaxValidatorClient();
+				val.validate(fix, profile, outf, level, maxErrs, null, files.toArray(new File[]{}), os);
+			}
+		} catch (Exception ex) {
+			// fall-back: not using the remote validator; trying to read files
+			String msg = "Unable to check with the biopax-validator web service: \n " +
+				ex.toString() +
+				"\n Fall-back: trying to parse the file(s) with paxtools " +
+				"(up to the first syntax error in each file)...\n";
+			log.error(msg, ex);
+			os.write(msg.getBytes());
 
-            for (File f : files) {
-                try {
-                    Model m = io.convertFromOWL(getInputStream(f.getPath()));
-                    msg = "Model that contains "
-                            + m.getObjects().size()
-                            + " elements is successfully created from " 
-                            + f.getPath() 
-                            + " (check the console output for warnings).\n";
-                    os.write(msg.getBytes());
-                } catch (Exception e) {
-                    msg = "Error: " + e + 
-                    		" in building a BioPAX Model from: " +
-                    		f.getPath() + "\n";
-                    os.write(msg.getBytes());
-                    e.printStackTrace();
-                    log.error(msg);
-                }
-                os.flush();
-            }
-        }
-    }
+			for (File f : files) {
+				try {
+					Model m = io.convertFromOWL(getInputStream(f.getPath()));
+					msg = "Model that contains "
+						+ m.getObjects().size()
+						+ " elements is successfully created from "
+						+ f.getPath()
+						+ " (check the console output for warnings).\n";
+					os.write(msg.getBytes());
+				} catch (Exception e) {
+					msg = "Error: " + e +
+						" in building a BioPAX Model from: " +
+						f.getPath() + "\n";
+					os.write(msg.getBytes());
+					e.printStackTrace();
+					log.error(msg);
+				}
+				os.flush();
+			}
+		}
+	}
 
 	/*
 	 * Exports a biopax model to SIF or/and customizable ExtendedSIF format
@@ -411,18 +409,15 @@ public final class PaxtoolsMain {
 	 *
 	 * TODO: should not be public API, but is already used from ext. apps, such as PaxtoolsR...
 	 */
-    public static void toSifnx(String[] argv) throws IOException
-	{
+	public static void toSifnx(String[] argv) throws IOException {
 		boolean extended = false; //if it stays 'false', then andSif==true will be in effect automatically
 		boolean andSif = false; //if extended==false, SIF will be generated as it would be andSif==true
 		boolean mergeInteractions = true;
 		boolean useNameIfNoId = false;
 		final Collection<SIFEnum> include = new HashSet<SIFEnum>();
 		final Collection<SIFEnum> exclude = new HashSet<SIFEnum>();
-
 		final ConfigurableIDFetcher idFetcher = new ConfigurableIDFetcher();
 		final List<String> customFieldList = new ArrayList<String>(); //there may be custom field names (SIF mediators)
-
 		//process arguments
 		if(argv.length > 3) {
 			for(int i=3; i<argv.length; i++) {
@@ -475,11 +470,10 @@ public final class PaxtoolsMain {
 		if(mergeInteractions)
 			ModelUtils.mergeEquivalentInteractions(model);
 
-
 		//Create a new SIF searcher:
 		//set SIF miners to use (default is to use all types, given no include/exclude args provided)
 		final Collection<SIFEnum> sifTypes = (include.isEmpty())
-				? new HashSet<SIFEnum>(Arrays.asList(SIFEnum.values())) : include;
+			? new HashSet<SIFEnum>(Arrays.asList(SIFEnum.values())) : include;
 		for(SIFType t : exclude) {
 			sifTypes.remove(t); //remove if exists, otherwise - ignore
 		}
@@ -501,12 +495,10 @@ public final class PaxtoolsMain {
 			//using built-in PC EXTENDED_BINARY_SIF format (customFieldList parameter is ignored)
 			Set<SIFInteraction> binaryInts = searcher.searchSIF(model);
 			ExtendedSIFWriter.write(binaryInts, outputStream);
-		}
-		else if (customFieldList.isEmpty()) {
+		} else if (customFieldList.isEmpty()) {
 			searcher.searchSIF(model, outputStream); //classic SIF
-		}
-		else {
-		// not really SIF format (this is useful but extra columns sometimes cannot be parsed correctly, by e.g. Cytoscape)
+		} else {
+			// not really SIF format (this is useful but extra columns sometimes cannot be parsed correctly, by e.g. Cytoscape)
 			log.info("toSIF: using custom fields (extra columns): " + customFieldList);
 			searcher.searchSIF(model, outputStream, new CustomFormat(customFieldList.toArray(new String[]{})));
 		}
@@ -518,11 +510,11 @@ public final class PaxtoolsMain {
 		}
 
 		log.info("toSIF: done.");
-    }
+	}
 
-    /*
-     * TODO: should not be public API, but is already used from ext. apps, such as PaxtoolsR...
-     */
+	/*
+	 * TODO: should not be public API, but is already used from ext. apps, such as PaxtoolsR...
+	 */
 	public static void sifnxToSif(String inputFile, String outputFile) throws IOException {
 		BufferedReader reader = new BufferedReader(new InputStreamReader(getInputStream(inputFile)));
 		OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(outputFile));
@@ -543,63 +535,63 @@ public final class PaxtoolsMain {
 	/*
 	 * TODO: should not be public API, but is already used from ext. apps, such as PaxtoolsR...
 	 */
-    public static void integrate(String[] argv) throws IOException {
+	public static void integrate(String[] argv) throws IOException {
 
-        Model model1 = getModel(io, argv[1]);
-        Model model2 = getModel(io, argv[2]);
+		Model model1 = getModel(io, argv[1]);
+		Model model2 = getModel(io, argv[2]);
 
-        Integrator integrator = new Integrator(SimpleEditorMap.get(model1.getLevel()), model1, model2);
-        integrator.integrate();
+		Integrator integrator = new Integrator(SimpleEditorMap.get(model1.getLevel()), model1, model2);
+		integrator.integrate();
 
-        io.setFactory(model1.getLevel().getDefaultFactory());
-        io.convertToOWL(model1, new FileOutputStream(argv[3]));
-    }
-
-    /*
-     * TODO: should not be public API, but is already used from ext. apps, such as PaxtoolsR...
-     */
-    public static void merge(String[] argv) throws IOException {
-
-        Model model1 = getModel(io, argv[1]);
-        Model model2 = getModel(io, argv[2]);
-
-        Merger merger = new Merger(SimpleEditorMap.get(model1.getLevel()));
-        merger.merge(model1, model2);
-
-        io.setFactory(model1.getLevel().getDefaultFactory());
-        io.convertToOWL(model1, new FileOutputStream(argv[3]));
-    }
+		io.setFactory(model1.getLevel().getDefaultFactory());
+		io.convertToOWL(model1, new FileOutputStream(argv[3]));
+	}
 
 	/*
-     * Generates a blacklist file
-     * (to optionally use it to exclude ubiquitous small molecules, 
-     * like ATP, when performing graph queries and exporting to
-     * SIF formats).
-     *
-     * TODO: should not be public API, but is already used from ext. apps, such as PaxtoolsR...
-     */
-    public static void blacklist(String[] argv) throws IOException {
-    	Model model = getModel(io, argv[1]);
+	 * TODO: should not be public API, but is already used from ext. apps, such as PaxtoolsR...
+	 */
+	public static void merge(String[] argv) throws IOException {
+
+		Model model1 = getModel(io, argv[1]);
+		Model model2 = getModel(io, argv[2]);
+
+		Merger merger = new Merger(SimpleEditorMap.get(model1.getLevel()));
+		merger.merge(model1, model2);
+
+		io.setFactory(model1.getLevel().getDefaultFactory());
+		io.convertToOWL(model1, new FileOutputStream(argv[3]));
+	}
+
+	/*
+	 * Generates a blacklist file
+	 * (to optionally use it to exclude ubiquitous small molecules,
+	 * like ATP, when performing graph queries and exporting to
+	 * SIF formats).
+	 *
+	 * TODO: should not be public API, but is already used from ext. apps, such as PaxtoolsR...
+	 */
+	public static void blacklist(String[] argv) throws IOException {
+		Model model = getModel(io, argv[1]);
 		BlacklistGenerator3 gen = new BlacklistGenerator3();
 		Blacklist blacklist = gen.generateBlacklist(model);
 		blacklist.write(new FileOutputStream(argv[2]));
-    }
+	}
 
-    /*
-     * TODO: should not be public API, but is already used from ext. apps, such as PaxtoolsR...
-     */
+	/*
+	 * TODO: should not be public API, but is already used from ext. apps, such as PaxtoolsR...
+	 */
 	public static void pattern(String[] argv) {
 		Dialog.main(argv);
 	}
 
-    private static Model getModel(BioPAXIOHandler io, String fName) throws IOException {
-        return io.convertFromOWL(getInputStream(fName));
-    }
+	private static Model getModel(BioPAXIOHandler io, String fName) throws IOException {
+		return io.convertFromOWL(getInputStream(fName));
+	}
 
 
-    /*
-     * TODO: should not be public API, but is already used from ext. apps, such as PaxtoolsR...
-     */
+	/*
+	 * TODO: should not be public API, but is already used from ext. apps, such as PaxtoolsR...
+	 */
 	public static void summarize(String[] argv) throws IOException {
 		log.debug("Importing the input model from " + argv[1] + "...");
 		final Model model = getModel(io, argv[1]);
@@ -691,12 +683,12 @@ public final class PaxtoolsMain {
 	 * @param includeEvidence whether to traverse into property:evidence to collect ids.
 	 */
 	private static Set<String> identifiers(final PhysicalEntity entity, final String xrefdb,
-										   boolean isPrefix, boolean includeEvidence)
+																				 boolean isPrefix, boolean includeEvidence)
 	{
 		final Set<String> ids = new HashSet<String>();
 		final Fetcher fetcher = (includeEvidence)
 			? new Fetcher(SimpleEditorMap.L3, Fetcher.nextStepFilter)
-				: new Fetcher(SimpleEditorMap.L3, Fetcher.nextStepFilter, Fetcher.evidenceFilter);
+			: new Fetcher(SimpleEditorMap.L3, Fetcher.nextStepFilter, Fetcher.evidenceFilter);
 		fetcher.setSkipSubPathways(true); //makes no difference now  but good to have/know...
 		Set<XReferrable> children = fetcher.fetch(entity, XReferrable.class);
 		children.add(entity); //include itself
@@ -704,8 +696,8 @@ public final class PaxtoolsMain {
 			if (child instanceof PhysicalEntity || child instanceof EntityReference || child instanceof Gene)
 				for (Xref x : child.getXref())
 					if ((x.getId()!=null && x.getDb()!=null) && (isPrefix)
-							? x.getDb().toLowerCase().startsWith(xrefdb.toLowerCase())
-								: xrefdb.equalsIgnoreCase(x.getDb()))
+						? x.getDb().toLowerCase().startsWith(xrefdb.toLowerCase())
+						: xrefdb.equalsIgnoreCase(x.getDb()))
 					{
 						ids.add(x.getId());
 					}
@@ -741,10 +733,10 @@ public final class PaxtoolsMain {
 		}
 		// print pathway names, etc. after a blank line and title line
 		out.println("\nPATHWAY_URI\tDATASOURCE\tDISPLAY_NAME\tALL_NAMES" +
-				"\tNUM_DIRECT_COMPONENT_OR_STEP_PROCESSES");
+			"\tNUM_DIRECT_COMPONENT_OR_STEP_PROCESSES");
 		for(Pathway pathway : pathways) {
 			final int size = pathwayComponentAccessor.getValueFromBean(pathway).size()
-					+ pathwayOrderStepProcessAccessor.getValueFromBean(pathway).size();
+				+ pathwayOrderStepProcessAccessor.getValueFromBean(pathway).size();
 			//pathways in PC2 normally has only one dataSource (Provenance)
 			String datasource = pathway.getDataSource().iterator().next().getDisplayName();
 			StringBuilder sb = new StringBuilder();
@@ -806,7 +798,7 @@ public final class PaxtoolsMain {
 				if (hgncSymbols.isEmpty() && hgncIds.isEmpty()) {
 					if (verbose) {
 						problemErs.add(String.format("%s\t%s\t%s",
-								((Provenance) provenance).getDisplayName(), ser.getDisplayName(), ser.getUri()));
+							((Provenance) provenance).getDisplayName(), ser.getDisplayName(), ser.getUri()));
 					}
 
 					MutableInt n = numProblematicErs.get(provenance);
@@ -857,11 +849,11 @@ public final class PaxtoolsMain {
 
 			for(Object provenance : pa.getValueFromBean(pr)) {
 				if(!pr.getUri().startsWith("http://identifiers.org/uniprot")
-						&& !pr.getXref().toString().toLowerCase().contains("uniprot")) {
+					&& !pr.getXref().toString().toLowerCase().contains("uniprot")) {
 
 					if (verbose) {
 						problemErs.add(String.format("%s\t%s\t%s",
-								((Provenance) provenance).getDisplayName(), pr.getDisplayName(), pr.getUri()));
+							((Provenance) provenance).getDisplayName(), pr.getDisplayName(), pr.getUri()));
 					}
 
 					MutableInt n = numProblematicErs.get(provenance);
@@ -912,11 +904,11 @@ public final class PaxtoolsMain {
 
 			for(Object provenance : pa.getValueFromBean(smr)) {
 				if(!smr.getUri().startsWith("http://identifiers.org/chebi/CHEBI:")
-						&& !smr.getXref().toString().contains("CHEBI:")) {
+					&& !smr.getXref().toString().contains("CHEBI:")) {
 
 					if (verbose) {
 						problemErs.add(String.format("%s\t%s\t%s",
-								((Provenance) provenance).getDisplayName(), smr.getDisplayName(), smr.getUri()));
+							((Provenance) provenance).getDisplayName(), smr.getDisplayName(), smr.getUri()));
 					}
 
 					MutableInt n = numProblematicErs.get(provenance);
@@ -960,9 +952,9 @@ public final class PaxtoolsMain {
 	 * @param model input Model
 	 * @param out output file
 	 * @throws IOException when an I/O exception occurs
-     */
+	 */
 	public static void summarize(Model model, PrintStream out) throws IOException {
-        HashMap<String, Integer> hm = new HashMap<String, Integer>();
+		HashMap<String, Integer> hm = new HashMap<String, Integer>();
 
 		final SimpleEditorMap em = SimpleEditorMap.get(model.getLevel());
 
@@ -972,7 +964,7 @@ public final class PaxtoolsMain {
 			int initialSize = set.size();
 			set = filterToExactClass(set, clazz);
 			String s = clazz.getSimpleName() + " = " + set.size();
-			if (initialSize != set.size()) 
+			if (initialSize != set.size())
 				s += " (and " + (initialSize - set.size()) + " children)";
 			out.println(s);
 
@@ -1019,7 +1011,7 @@ public final class PaxtoolsMain {
 
 				if (!cnt.isEmpty())
 				{
-					String name = "-" 
+					String name = "-"
 						+ (returnType.equals(Set.class) ? editor.getRange().getSimpleName() : returnType.getSimpleName());
 
 					out.print("\t" + name + ":");
@@ -1041,13 +1033,13 @@ public final class PaxtoolsMain {
 			Map<Object, Integer> cnt = new HashMap<Object, Integer>();
 			List<String> valList = new ArrayList<String>();
 			PathAccessor acc = new PathAccessor(prop, model.getLevel());
-			
+
 			boolean isString = false;
-			
+
 			for (Object o : acc.getValueFromModel(model))
 			{
 				if (o instanceof String) isString = true;
-				
+
 				String s = o.toString();
 				valList.add(s);
 				if (!cnt.containsKey(s)) cnt.put(s, 1);
@@ -1055,7 +1047,7 @@ public final class PaxtoolsMain {
 			}
 
 			out.println(prop + "\t(" + cnt.size() + " distinct values):");
-            hm.put(prop, cnt.size());
+			hm.put(prop, cnt.size());
 
 			// If the object is String, then all counts are 1, no need to print counts.
 			if (isString)
@@ -1154,15 +1146,15 @@ public final class PaxtoolsMain {
 		out.println(
 			String.format(
 				"\n%d Genes, %d Pathways, %d SequenceEntityReferences " +
-				"(%d in NucleicAcidRef. and %d in PRs) have NULL 'organism'.\n",
+					"(%d in NucleicAcidRef. and %d in PRs) have NULL 'organism'.\n",
 				genesLackingOrganism, pwLackingOrganism, serLackingOrganism,
 				narLackingOrganism, serLackingOrganism-narLackingOrganism
 			)
 		);
 	}
 
-	private static List<Class<? extends BioPAXElement>> sortToName(Set<? extends Class<? extends BioPAXElement>>
-			classes)
+	private static List<Class<? extends BioPAXElement>> sortToName(
+		Set<? extends Class<? extends BioPAXElement>> classes)
 	{
 		List<Class<? extends BioPAXElement>> list = new ArrayList<Class<? extends BioPAXElement>>(classes);
 		Collections.sort(list, new Comparator<Class<? extends  BioPAXElement>>() {
@@ -1172,11 +1164,11 @@ public final class PaxtoolsMain {
 					clazz2.getName().substring(clazz2.getName().lastIndexOf(".")+1));
 			}
 		});
+
 		return list;
 	}
 
-	private static List<Object> getOrdering(final Map<Object, Integer> map)
-	{
+	private static List<Object> getOrdering(final Map<Object, Integer> map) {
 		List<Object> list = new ArrayList<Object>(map.keySet());
 		Collections.sort(list, new Comparator<Object>()
 		{
@@ -1189,16 +1181,17 @@ public final class PaxtoolsMain {
 				else return cnt2 - cnt1;
 			}
 		});
+
 		return list;
 	}
-	
+
 	private static Set<BioPAXElement> filterToExactClass(Set<? extends BioPAXElement> classSet, Class<?> clazz)
 	{
 		Set<BioPAXElement> exact = new HashSet<BioPAXElement>();
-		for (BioPAXElement ele : classSet)
-		{
+		for (BioPAXElement ele : classSet) {
 			if (ele.getModelInterface().equals(clazz)) exact.add(ele);
 		}
+
 		return exact;
 	}
 
@@ -1218,22 +1211,21 @@ public final class PaxtoolsMain {
 		}
 	};
 
-	private static boolean implementsInterface(Class clazz, Class inter)
-	{
-		for (Class anInter : clazz.getInterfaces())
-		{
-			if (anInter.equals(inter)) return true;
+	private static boolean implementsInterface(Class clazz, Class inter) {
+		for (Class anInter : clazz.getInterfaces()) {
+			if (anInter.equals(inter))
+				return true;
 		}
+
 		return false;
 	}
 
-	private static void increaseCnt(Map<Object, Integer> cnt, Object key)
-	{
-		if (!cnt.containsKey(key)) cnt.put(key, 0);
+	private static void increaseCnt(Map<Object, Integer> cnt, Object key) {
+		if (!cnt.containsKey(key))
+			cnt.put(key, 0);
 		cnt.put(key, cnt.get(key) + 1);
 	}
-	
-	
+
 	// gets new IS - either FIS or GzipIS if .gz extension present
 	private static InputStream getInputStream(String path) throws IOException {
 		InputStream is = new FileInputStream(path);

--- a/paxtools-core/pom.xml
+++ b/paxtools-core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.biopax.paxtools</groupId>
 		<artifactId>paxtools</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.2.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>paxtools-core</artifactId>

--- a/paxtools-query/pom.xml
+++ b/paxtools-query/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <artifactId>paxtools</artifactId>
         <groupId>org.biopax.paxtools</groupId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>5.2.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/paxtools-search/pom.xml
+++ b/paxtools-search/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>paxtools</artifactId>
 		<groupId>org.biopax.paxtools</groupId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.2.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>paxtools-search</artifactId>
@@ -45,10 +45,6 @@
 			<groupId>org.apache.lucene</groupId>
 			<artifactId>lucene-queryparser</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-		</dependency>	
 	</dependencies>
 
 	<dependencyManagement>

--- a/paxtools-trove/pom.xml
+++ b/paxtools-trove/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.biopax.paxtools</groupId>
 		<artifactId>paxtools</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.2.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>paxtools-trove</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>org.biopax.paxtools</groupId>
   <artifactId>paxtools</artifactId>
-  <version>5.2.0-SNAPSHOT</version>
+  <version>5.2.1-SNAPSHOT</version>
 
   <name>Paxtools</name>
 
@@ -62,7 +62,7 @@
     <maven-site-plugin.version>3.4</maven-site-plugin.version>
     <maven-javadoc-plugin.version>2.10.2</maven-javadoc-plugin.version>
     <maven-jxr-plugin.version>2.5</maven-jxr-plugin.version>
-    <maven-project-info-reports-plugin.version>2.8</maven-project-info-reports-plugin.version>
+    <maven-project-info-reports-plugin.version>2.9</maven-project-info-reports-plugin.version>
     <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
     <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.5</nexus-staging-maven-plugin.version>
@@ -579,6 +579,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>${maven-project-info-reports-plugin.version}</version>
         <configuration>
           <dependencyDetailsEnabled>false</dependencyDetailsEnabled>
           <dependencyLocationsEnabled>false</dependencyLocationsEnabled>

--- a/psimi-converter/pom.xml
+++ b/psimi-converter/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.biopax.paxtools</groupId>
         <artifactId>paxtools</artifactId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>5.2.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/sbgn-converter/pom.xml
+++ b/sbgn-converter/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <artifactId>paxtools</artifactId>
         <groupId>org.biopax.paxtools</groupId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>5.2.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sbgn-converter/src/main/java/org/biopax/paxtools/io/sbgn/L3ToSBGNPDConverter.java
+++ b/sbgn-converter/src/main/java/org/biopax/paxtools/io/sbgn/L3ToSBGNPDConverter.java
@@ -14,15 +14,16 @@ import org.sbgn.SbgnUtil;
 import org.sbgn.bindings.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
+//import org.w3c.dom.Document;
+//import org.w3c.dom.Element;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
+//import javax.xml.parsers.DocumentBuilder;
+//import javax.xml.parsers.DocumentBuilderFactory;
+//import javax.xml.parsers.ParserConfigurationException;
+
 import java.io.File;
 import java.io.OutputStream;
 import java.text.DecimalFormat;
@@ -51,8 +52,7 @@ import java.util.Map;
  *
  * @author Ozgun Babur
  */
-public class L3ToSBGNPDConverter
-{
+public class L3ToSBGNPDConverter {
 	private static final Logger log = LoggerFactory.getLogger(L3ToSBGNPDConverter.class);
 
 	/**
@@ -135,13 +135,10 @@ public class L3ToSBGNPDConverter
 	 */
 	Set<Glyph> ubiqueSet;
 
-
-// this is to store BioPAX metadata in the SBGN-ML Extensions or Notes.
-	private static Document biopaxMetaDoc;
+//	private static Document biopaxMetaDoc; //see issue #40
 
 	//-- Section: Static initialization -----------------------------------------------------------|
-	static
-	{
+	static {
 		factory = new ObjectFactory();
 		typeMatchMap = new HashMap<Class<? extends BioPAXElement>, String>();
 		typeMatchMap.put(Protein.class, GlyphClazz.MACROMOLECULE.getClazz());
@@ -152,21 +149,20 @@ public class L3ToSBGNPDConverter
 		typeMatchMap.put(RnaRegion.class, GlyphClazz.NUCLEIC_ACID_FEATURE.getClazz());
 		typeMatchMap.put(NucleicAcid.class, GlyphClazz.NUCLEIC_ACID_FEATURE.getClazz());
 		typeMatchMap.put(PhysicalEntity.class, GlyphClazz.UNSPECIFIED_ENTITY.getClazz());
-		//TODO: SimplePhysicalEntity is a non-instantiable abstract type in Paxtools; remove the mapping below?
+		//TODO: remove SimplePhysicalEntity.class key (- abstract type)?
 		typeMatchMap.put(SimplePhysicalEntity.class, GlyphClazz.UNSPECIFIED_ENTITY.getClazz());
 		typeMatchMap.put(Complex.class, GlyphClazz.COMPLEX.getClazz());
 		typeMatchMap.put(Gene.class, GlyphClazz.NUCLEIC_ACID_FEATURE.getClazz());
 
-		//a document for adding metadata elements to insert into SBGN-ML PD glyphs (inside Extensions/Notes element).
-		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-		try {
-			DocumentBuilder db = dbf.newDocumentBuilder();
-			db.reset();
-			biopaxMetaDoc = db.newDocument();
-		} catch (ParserConfigurationException e) {
-			throw new RuntimeException("Cannot initialize BioPAX extensions DOM.", e);
-		}
-
+//		//a document for adding metadata elements to insert into SBGN-ML PD glyphs (inside Extensions/Notes element).
+//		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+//		try {
+//			DocumentBuilder db = dbf.newDocumentBuilder();
+//			db.reset();
+//			biopaxMetaDoc = db.newDocument();
+//		} catch (ParserConfigurationException e) {
+//			throw new RuntimeException("Cannot initialize BioPAX extensions DOM.", e);
+//		}
 	}
 
 	//-- Section: Public methods ------------------------------------------------------------------|
@@ -357,14 +353,14 @@ public class L3ToSBGNPDConverter
 		map.getGlyph().addAll(compartmentMap.values());
 		map.getArc().addAll(arcMap.values());
 
-    //Store some metadata within the standard SBGN-ML extension element: Notes
-		biopaxMetaDoc.setDocumentURI(model.getUri()); //can be null
-		SBGNBase.Notes modelNotes = new SBGNBase.Notes();
-		sbgn.setNotes(modelNotes);
-		Element elt = biopaxMetaDoc.createElementNS("","metadata");
-		elt.setTextContent(String.format("{name:\"%s\",uri:\"%s\"}", model.getName(), model.getUri())
-			.replaceAll("null",""));
-		modelNotes.getAny().add(elt);
+//    //Store some metadata within the standard SBGN-ML extension element: Notes
+//		biopaxMetaDoc.setDocumentURI(model.getUri()); //can be null
+//		SBGNBase.Notes modelNotes = new SBGNBase.Notes();
+//		sbgn.setNotes(modelNotes);
+//		Element elt = biopaxMetaDoc.createElementNS("","metadata");
+//		elt.setTextContent(String.format("{name:\"%s\",uri:\"%s\"}", model.getName(), model.getUri())
+//			.replaceAll("null",""));
+//		modelNotes.getAny().add(elt);
 
 		final boolean layout = doLayout && n < this.maxNodes && !arcMap.isEmpty();
 		try {

--- a/sbgn-converter/src/test/java/org/biopax/paxtools/io/sbgn/SBGNConverterTest.java
+++ b/sbgn-converter/src/test/java/org/biopax/paxtools/io/sbgn/SBGNConverterTest.java
@@ -232,20 +232,21 @@ public class SBGNConverterTest
 	// it's probably about an unknown/omitted sub-pathway with known in/out chemicals,
 	// but it's expressed in BioPAX badly (a Pathway with one Interaction and PathwayStep, and no comments...)
 	@Test
-	public void testConvertOmittedSmpdbPathway()
-	{
+	public void testConvertOmittedSmpdbPathway() throws JAXBException {
 		String input = "/smpdb-beta-oxidation";
 		InputStream in = getClass().getResourceAsStream(input + ".owl");
 		Model level3 = handler.convertFromOWL(in);
 		String out = "target/" + input + ".sbgn";
 		L3ToSBGNPDConverter conv = new L3ToSBGNPDConverter(blacklist,null, false);
 		conv.writeSBGN(level3, out);
+
+		Sbgn result = (Sbgn) unmarshaller.unmarshal(new File(out));
+		assertFalse(result.getMap().getGlyph().isEmpty());
     //TODO: add assertions
 	}
 
 	@Test
-	public void testConvertBadWikiPathway()
-	{
+	public void testConvertBadWikiPathway() throws JAXBException {
 		String input = "/WP561";
 		InputStream in = getClass().getResourceAsStream(input + ".owl");
 		Model level3 = handler.convertFromOWL(in);
@@ -253,6 +254,10 @@ public class SBGNConverterTest
 
 		L3ToSBGNPDConverter conv = new L3ToSBGNPDConverter(blacklist,null, true);
 		conv.writeSBGN(level3, out);
+
+		Sbgn result = (Sbgn) unmarshaller.unmarshal(new File(out));
+		assertFalse(result.getMap().getGlyph().isEmpty());
+
 		//TODO: add assertions
 	}
 
@@ -267,7 +272,7 @@ public class SBGNConverterTest
 		// Now read from "f" and put the result in "sbgn"
 		Sbgn result = (Sbgn)unmarshaller.unmarshal (sbgnFile);
 		// Assert that the sbgn result contains glyphs
-		assertTrue(!result.getMap().getGlyph().isEmpty());
+		assertFalse(result.getMap().getGlyph().isEmpty());
 
 		// infinite loop in LGraph.updateConnected when SbgnPDLayout is used
 		(new SBGNLayoutManager()).createLayout(result, true);
@@ -275,9 +280,8 @@ public class SBGNConverterTest
 		marshaller.marshal(result, new FileOutputStream("target/hsa00051.out.sbgn"));
 	}
 
-
 	@Test
-	public void testConvertGIs() {
+	public void testConvertGIs() throws JAXBException {
 		String out = "target/test_gi.sbgn";
 		MockFactory f = new MockFactory(BioPAXLevel.L3);
 		Model m = f.createModel();
@@ -293,11 +297,13 @@ public class SBGNConverterTest
 		L3ToSBGNPDConverter conv = new L3ToSBGNPDConverter();
 		conv.setDoLayout(true);
 		conv.writeSBGN(m, out);
+
+		Sbgn result = (Sbgn) unmarshaller.unmarshal(new File(out));
+		assertFalse(result.getMap().getGlyph().isEmpty());
 	}
 
 	@Test
-	public void testConvertTRs()
-	{
+	public void testConvertTRs() throws JAXBException {
 		String out = "target/test_tr.sbgn";
 		MockFactory f = new MockFactory(BioPAXLevel.L3);
 		Model m = f.createModel();
@@ -324,6 +330,9 @@ public class SBGNConverterTest
 		L3ToSBGNPDConverter conv = new L3ToSBGNPDConverter();
 		conv.setDoLayout(true);
 		conv.writeSBGN(m, out);
+
+		Sbgn result = (Sbgn) unmarshaller.unmarshal(new File(out));
+		assertFalse(result.getMap().getGlyph().isEmpty());
 	}
 
 	@Test
@@ -347,10 +356,9 @@ public class SBGNConverterTest
 
 		// Now read the SBGN model back
 		Sbgn result = (Sbgn) unmarshaller.unmarshal (outFile);
-
 		// Assert that the sbgn result contains glyphs
     List<Glyph> glyphList = result.getMap().getGlyph();
-		assertTrue(!glyphList.isEmpty());
+		assertFalse(glyphList.isEmpty());
 	}
 
 	@Test
@@ -362,9 +370,7 @@ public class SBGNConverterTest
 		String out = "target/" + input + ".sbgn";
 		L3ToSBGNPDConverter conv = new L3ToSBGNPDConverter(blacklist,null, true);
 		conv.writeSBGN(m, out);
-
     Sbgn result = (Sbgn) unmarshaller.unmarshal(new File(out));
-
     assertFalse(result.getMap().getGlyph().isEmpty());
     Collection<Arc> filtered = filterArcsByClazz(result.getMap().getArc(), "stimulation");
     assertFalse(filtered.isEmpty());
@@ -400,14 +406,14 @@ public class SBGNConverterTest
     assertFalse(filtered.isEmpty());
   }
 
-	private Collection<Glyph> filterGlyphsByClazz(Collection<Glyph> collection, String clazz) {
-    Set<Glyph> filtered = new HashSet<Glyph>();
-    for(Glyph g : collection)
-      if(g.getClazz().equals(clazz))
-        filtered.add(g);
-
-    return filtered;
-  }
+//	private Collection<Glyph> filterGlyphsByClazz(Collection<Glyph> collection, String clazz) {
+//    Set<Glyph> filtered = new HashSet<Glyph>();
+//    for(Glyph g : collection)
+//      if(g.getClazz().equals(clazz))
+//        filtered.add(g);
+//
+//    return filtered;
+//  }
 
   private Collection<Arc> filterArcsByClazz(Collection<Arc> collection, String clazz) {
     Set<Arc> filtered = new HashSet<Arc>();

--- a/sbgn-converter/src/test/resources/activation.owl
+++ b/sbgn-converter/src/test/resources/activation.owl
@@ -1,0 +1,44 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:owl="http://www.w3.org/2002/07/owl#"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+  xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#">
+  <owl:Ontology rdf:about="">
+    <owl:imports rdf:resource="http://www.biopax.org/release/biopax-level3.owl#" />
+  </owl:Ontology>
+  <bp:Protein rdf:about="f98f403f-ab47-4d50-a9c1-dd0c62ddb929">
+    <bp:displayName rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">FSHB</bp:displayName>
+    <bp:entityReference rdf:resource="61a166af-cabc-4f37-82dc-205cd763a354" />
+  </bp:Protein>
+  <bp:ProteinReference rdf:about="61a166af-cabc-4f37-82dc-205cd763a354">
+    <bp:xref rdf:resource="6b54a312-f1ce-46c1-aa65-23a475d8a448" />
+    <bp:displayName rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">FSHB</bp:displayName>
+  </bp:ProteinReference>
+  <bp:RelationshipXref rdf:about="6b54a312-f1ce-46c1-aa65-23a475d8a448">
+    <bp:id rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">P01225</bp:id>
+    <bp:db rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">uniprot</bp:db>
+  </bp:RelationshipXref>
+  <bp:Protein rdf:about="2e8917ce-7b7c-42dd-ba0a-fee2b139dd3e">
+    <bp:displayName rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">IGF1</bp:displayName>
+    <bp:entityReference rdf:resource="7a1b2976-619c-439e-a3e8-d9064519d60b" />
+  </bp:Protein>
+  <bp:ProteinReference rdf:about="7a1b2976-619c-439e-a3e8-d9064519d60b">
+    <bp:xref rdf:resource="4090cd2e-f146-4c85-9478-5af0818f19cf" />
+    <bp:displayName rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">IGF1</bp:displayName>
+  </bp:ProteinReference>
+  <bp:RelationshipXref rdf:about="4090cd2e-f146-4c85-9478-5af0818f19cf">
+    <bp:id rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">P05019</bp:id>
+    <bp:db rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">uniprot</bp:db>
+  </bp:RelationshipXref>
+  <bp:Control rdf:about="9d9700c6-a390-4ebe-91a9-82c4a89ea5ee">
+    <bp:comment>FSHB activates IGF1</bp:comment>
+    <bp:controlled rdf:resource="93d7ff4e-2943-45bf-aca9-16ff4241a7c0" />
+    <bp:controller rdf:resource="f98f403f-ab47-4d50-a9c1-dd0c62ddb929" />
+    <bp:controlType rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">ACTIVATION</bp:controlType>
+  </bp:Control>
+  <bp:Control rdf:about="93d7ff4e-2943-45bf-aca9-16ff4241a7c0">
+    <bp:controller rdf:resource="2e8917ce-7b7c-42dd-ba0a-fee2b139dd3e" />
+    <bp:controlType rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">ACTIVATION</bp:controlType>
+  </bp:Control>
+</rdf:RDF>

--- a/sbgn-converter/src/test/resources/controlchain.owl
+++ b/sbgn-converter/src/test/resources/controlchain.owl
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:owl="http://www.w3.org/2002/07/owl#"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+  xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#">
+  <owl:Ontology rdf:about="">
+    <owl:imports rdf:resource="http://www.biopax.org/release/biopax-level3.owl#" />
+  </owl:Ontology>
+  <bp:SmallMolecule rdf:about="28ee35e1-de08-4cec-91c9-cfbadae683ef">
+    <bp:displayName rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">Estradiol</bp:displayName>
+    <bp:entityReference rdf:resource="e9d5ce7b-71d9-442d-970e-b768dc7c7418" />
+  </bp:SmallMolecule>
+  <bp:SmallMoleculeReference rdf:about="e9d5ce7b-71d9-442d-970e-b768dc7c7418">
+    <bp:xref rdf:resource="150e9163-9811-4ab8-9442-54dbb16a39d5" />
+    <bp:displayName rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">Estradiol</bp:displayName>
+  </bp:SmallMoleculeReference>
+  <bp:RelationshipXref rdf:about="150e9163-9811-4ab8-9442-54dbb16a39d5">
+    <bp:id rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">5757</bp:id>
+    <bp:db rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">pubchem</bp:db>
+  </bp:RelationshipXref>
+  <bp:Protein rdf:about="1a6dedda-6fa6-436e-836a-1c1c58be526a">
+    <bp:displayName rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">LEP</bp:displayName>
+    <bp:entityReference rdf:resource="10e75ab2-b79d-4359-af37-e90e3a7473e7" />
+  </bp:Protein>
+  <bp:ProteinReference rdf:about="10e75ab2-b79d-4359-af37-e90e3a7473e7">
+    <bp:xref rdf:resource="88f99df9-6771-44aa-8514-95071e84476b" />
+    <bp:displayName rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">LEP</bp:displayName>
+  </bp:ProteinReference>
+  <bp:RelationshipXref rdf:about="88f99df9-6771-44aa-8514-95071e84476b">
+    <bp:id rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">P41159</bp:id>
+    <bp:db rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">uniprot</bp:db>
+  </bp:RelationshipXref>
+  <bp:Modulation rdf:about="f0ae2f3a-f88c-40ad-8d25-c653ae636aba">
+    <bp:comment>Estradiol activates LEP</bp:comment>
+    <bp:controlled rdf:resource="fb03be15-e844-4e5b-92d3-1d527efbabbe" />
+    <bp:controller rdf:resource="28ee35e1-de08-4cec-91c9-cfbadae683ef" />
+    <bp:controlType rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">ACTIVATION</bp:controlType>
+  </bp:Modulation>
+  <bp:Catalysis rdf:about="fb03be15-e844-4e5b-92d3-1d527efbabbe">
+    <bp:controller rdf:resource="1a6dedda-6fa6-436e-836a-1c1c58be526a" />
+    <bp:controlType rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">ACTIVATION</bp:controlType>
+  </bp:Catalysis>
+  <bp:Protein rdf:about="f1ba976f-d460-4c70-a3de-29c5ca28b393">
+    <bp:displayName rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">BMP2</bp:displayName>
+    <bp:entityReference rdf:resource="c06b19ab-b556-467e-8432-eea7464ecf8c" />
+  </bp:Protein>
+  <bp:ProteinReference rdf:about="c06b19ab-b556-467e-8432-eea7464ecf8c">
+    <bp:xref rdf:resource="5b471826-6728-48c1-8a35-6c5ccd89e07a" />
+    <bp:displayName rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">BMP2</bp:displayName>
+  </bp:ProteinReference>
+  <bp:RelationshipXref rdf:about="5b471826-6728-48c1-8a35-6c5ccd89e07a">
+    <bp:id rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">P12643</bp:id>
+    <bp:db rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">uniprot</bp:db>
+  </bp:RelationshipXref>
+  <bp:Control rdf:about="bmp2-controls-activation-of-lep-by-estradiol">
+    <bp:controlled rdf:resource="f0ae2f3a-f88c-40ad-8d25-c653ae636aba" />
+    <bp:controller rdf:resource="f1ba976f-d460-4c70-a3de-29c5ca28b393" />
+    <bp:controlType rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">ACTIVATION</bp:controlType>
+  </bp:Control>
+</rdf:RDF>

--- a/sbgn-converter/src/test/resources/modulation.owl
+++ b/sbgn-converter/src/test/resources/modulation.owl
@@ -1,0 +1,44 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:owl="http://www.w3.org/2002/07/owl#"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+  xmlns:bp="http://www.biopax.org/release/biopax-level3.owl#">
+  <owl:Ontology rdf:about="">
+    <owl:imports rdf:resource="http://www.biopax.org/release/biopax-level3.owl#" />
+  </owl:Ontology>
+  <bp:SmallMolecule rdf:about="28ee35e1-de08-4cec-91c9-cfbadae683ef">
+    <bp:displayName rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">Estradiol</bp:displayName>
+    <bp:entityReference rdf:resource="e9d5ce7b-71d9-442d-970e-b768dc7c7418" />
+  </bp:SmallMolecule>
+  <bp:SmallMoleculeReference rdf:about="e9d5ce7b-71d9-442d-970e-b768dc7c7418">
+    <bp:xref rdf:resource="150e9163-9811-4ab8-9442-54dbb16a39d5" />
+    <bp:displayName rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">Estradiol</bp:displayName>
+  </bp:SmallMoleculeReference>
+  <bp:RelationshipXref rdf:about="150e9163-9811-4ab8-9442-54dbb16a39d5">
+    <bp:id rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">5757</bp:id>
+    <bp:db rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">pubchem</bp:db>
+  </bp:RelationshipXref>
+  <bp:Protein rdf:about="1a6dedda-6fa6-436e-836a-1c1c58be526a">
+    <bp:displayName rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">LEP</bp:displayName>
+    <bp:entityReference rdf:resource="10e75ab2-b79d-4359-af37-e90e3a7473e7" />
+  </bp:Protein>
+  <bp:ProteinReference rdf:about="10e75ab2-b79d-4359-af37-e90e3a7473e7">
+    <bp:xref rdf:resource="88f99df9-6771-44aa-8514-95071e84476b" />
+    <bp:displayName rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">LEP</bp:displayName>
+  </bp:ProteinReference>
+  <bp:RelationshipXref rdf:about="88f99df9-6771-44aa-8514-95071e84476b">
+    <bp:id rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">P41159</bp:id>
+    <bp:db rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">uniprot</bp:db>
+  </bp:RelationshipXref>
+  <bp:Modulation rdf:about="f0ae2f3a-f88c-40ad-8d25-c653ae636aba">
+    <bp:comment>Estradiol activates LEP</bp:comment>
+    <bp:controlled rdf:resource="fb03be15-e844-4e5b-92d3-1d527efbabbe" />
+    <bp:controller rdf:resource="28ee35e1-de08-4cec-91c9-cfbadae683ef" />
+    <bp:controlType rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">ACTIVATION</bp:controlType>
+  </bp:Modulation>
+  <bp:Catalysis rdf:about="fb03be15-e844-4e5b-92d3-1d527efbabbe">
+    <bp:controller rdf:resource="1a6dedda-6fa6-436e-836a-1c1c58be526a" />
+    <bp:controlType rdf:datatype = "http://www.w3.org/2001/XMLSchema#string">ACTIVATION</bp:controlType>
+  </bp:Catalysis>
+</rdf:RDF>


### PR DESCRIPTION
- refs #41 and PathwayCommons/factoid#401 and more
- fixed various issues that previously caused some models, when converted from BioPAX to SBGN, look really bad in NEWT/SBGNViz apps, which seems to be caused by particular glyph-arc clazz combinations, such as "process" glyph and "interaction" arcs in some cases produced by the sbgn-converter.