### PR TITLE
GH-54 XSD Datatype should use full IRI in rdf/xml datatype attribute

### DIFF
--- a/paxtools-core/src/main/java/org/biopax/paxtools/io/SimpleIOHandler.java
+++ b/paxtools-core/src/main/java/org/biopax/paxtools/io/SimpleIOHandler.java
@@ -666,7 +666,7 @@ public final class SimpleIOHandler extends BioPAXIOHandlerAdapter
 		{
 			String type = findLiteralType(editor);
 			String valString = escapeXml(value.toString());
-			out.write(" rdf:datatype = \"xsd:"  + type + "\">" + valString +
+			out.write(" rdf:datatype = \"http://www.w3.org/2001/XMLSchema#"  + type + "\">" + valString +
 			          "</" + prop + ">");
 		}
 	}


### PR DESCRIPTION
This was already the case in all the test files. So this does not really change anything at this point inside the code repository.

Closes #54