### PR TITLE
GH-54 allow using RDF 1.1 (no need for xsd:string) and/or XML entitie…

### DIFF
--- a/paxtools-core/src/test/java/org/biopax/paxtools/io/SimpleIOHandlerTest.java
+++ b/paxtools-core/src/test/java/org/biopax/paxtools/io/SimpleIOHandlerTest.java
@@ -64,6 +64,26 @@ public class SimpleIOHandlerTest {
         .getFile() + File.separator + "simpleReadWrite.owl");
     io.convertToOWL(model, out);
   }
+  
+  @Test
+  public void readWriteL3WithDifferentSettings() throws IOException {
+    BioPAXIOHandler io = new SimpleIOHandler(BioPAXLevel.L3.getDefaultFactory(), BioPAXLevel.L3, true, true);
+    Model model = getL3Model(io);
+    assertNotNull(model);
+    assertFalse(model.getObjects().isEmpty());
+    System.out.println("Model has " + model.getObjects().size() + " objects)");
+    String path = getClass().getResource("")
+        .getFile() + File.separator + "simpleReadWrite.owl";
+	try (FileOutputStream out = new FileOutputStream(path)){	
+		io.convertToOWL(model, out);
+	}
+	Model model2 ;
+    try (FileInputStream in = new FileInputStream(new File(path))){
+    	model2 = io.convertFromOWL(in);
+    }
+    assertEquals(model.getName(), model2.getName());
+    assertEquals(model.getNameSpacePrefixMap(), model2.getNameSpacePrefixMap());
+  }
 
   public static Model getL3Model(BioPAXIOHandler io) {
     String s = "L3" + File.separator + "biopax3-short-metabolic-pathway.owl";


### PR DESCRIPTION
…s to make long IRI's for xsd datatype references without introducing a lot of bytes

A second attempt at closing #54 not increasing the file size so much. Also reducing the printed datatypes as in RDF 1.1 xsd:string and no datatype are the same. 

Both added as configurable options. 

@IgorRodchenkov is this better than the first pull request? anything else I should do to improve it? Thank you again for your consideration. Also if I should aim it a different branch please let me know.